### PR TITLE
Remove bar_feature feature

### DIFF
--- a/scripts/features.h
+++ b/scripts/features.h
@@ -1,4 +1,2 @@
 const ALString kFoo = "foo_feature";
-const ALString kBar = "bar_feature";
 const ALString kBaz = "baz_feature";
-

--- a/scripts/foo.cpp
+++ b/scripts/foo.cpp
@@ -22,12 +22,7 @@ int main()
 {
     Context context;
 
-    AL_ENABLED("bar_feature", context)
-    {
-        return 0;
-    }
-    else
-    {
-        return 1;
-    }
+    
+    return 1;
+
 }


### PR DESCRIPTION
## summary
Feature bar_feature referenced in 1 file
 * /Users/bsergeant/src/foss/autoroute/scripts/foo.cpp
## clang-tidy invocation
```
/opt/applovin/bin/clang-tidy --config="
CheckOptions:
- key:             applovin-al-enabled.DisabledFeatures
  value:           'bar_feature'
    " -checks=applovin-al-enabled -fix -fix-errors -p . /Users/bsergeant/src/foss/autoroute/scripts/foo.cpp1 warning generated.
/Users/bsergeant/src/foss/autoroute/scripts/foo.cpp:25:5: warning: Feature bar_feature is fully enabled, consider scaling [applovin-al-enabled]
    AL_ENABLED("bar_feature", context)
    ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/Users/bsergeant/src/foss/autoroute/scripts/foo.cpp:25:5: note: FIX-IT applied suggested code changes
/Users/bsergeant/src/foss/autoroute/scripts/foo.cpp:19:5: note: expanded from macro 'AL_ENABLED'
    if (context.featureSettings().__isFeatureEnabled((name )))
    ^
clang-tidy applied 1 of 1 suggested fixes.


```
